### PR TITLE
patched bug where empty multi_tags weren't rendering an error when betwe...

### DIFF
--- a/lib/ruby-bbcode/tag_sifter.rb
+++ b/lib/ruby-bbcode/tag_sifter.rb
@@ -124,13 +124,22 @@ module RubyBBCode
     def handle_closing_tags_that_are_multi_as_text_if_it_doesnt_match_the_latest_opener_tag_on_the_stack
       if @ti.element_is_closing_tag?
         return if @bbtree.current_node[:definition].nil?
-        if parent_tag != @ti[:tag] and @bbtree.current_node[:definition][:multi_tag]       # if opening tag doesn't match this closing tag... and if the opener was a multi_tag...
+        if current_tag_is_of_differing_type_from_parent and @bbtree.current_node[:definition][:multi_tag]       # if opening tag doesn't match this closing tag... and if the opener was a multi_tag...
           @ti.handle_tag_as_text
         end
       end
     end
 
     private
+
+    def current_tag_is_of_same_type_as_parent
+      return false if parent_tag.nil?
+      parent_tag[:tag] == @ti[:tag]
+    end
+
+    def current_tag_is_of_differing_type_from_parent
+      !current_tag_is_of_same_type_as_parent
+    end
 
     def create_text_element
       element = {:is_tag => false, :text => @ti.text, :errors => @ti[:errors] }
@@ -235,7 +244,7 @@ module RubyBBCode
         end
 
         tag_def = @bbtree.current_node.definition
-        if tag_def[:require_between] and @bbtree.current_node[:between].nil?
+        if (tag_def[:require_between] or tag_def[:multi_tag]) and @bbtree.current_node[:between].nil?
           add_tag_error "No text between [#{@ti[:tag]}] and [/#{@ti[:tag]}] tags.", @bbtree.current_node
           return false
         end

--- a/lib/ruby-bbcode/tag_sifter.rb
+++ b/lib/ruby-bbcode/tag_sifter.rb
@@ -243,13 +243,18 @@ module RubyBBCode
           end
         end
 
-        tag_def = @bbtree.current_node.definition
-        if (tag_def[:require_between] or tag_def[:multi_tag]) and @bbtree.current_node[:between].nil?
+        
+        if current_tag_requires_between_but_none_given?
           add_tag_error "No text between [#{@ti[:tag]}] and [/#{@ti[:tag]}] tags.", @bbtree.current_node
           return false
         end
       end
       true
+    end
+    
+    def current_tag_requires_between_but_none_given?
+      tag_def = @bbtree.current_node.definition
+      (tag_def[:require_between] or (tag_def[:multi_tag]) and tag_def[:require_between] != false) and @bbtree.current_node[:between].nil?
     end
 
     def parent_of_self_closing_tag?

--- a/test/ruby_bbcode_html_test.rb
+++ b/test/ruby_bbcode_html_test.rb
@@ -100,6 +100,11 @@ class RubyBbcodeHtmlTest < Minitest::Test
                    '[youtube]E4Fbk52Mk1w[/youtube]'.bbcode_to_html
   end
 
+  def test_errors_dont_prevent_further_processing
+    assert_equal '[media][/media]<object width="400" height="325"><param name="movie" value="http://www.youtube.com/v/E4Fbk52Mk1w"></param><embed src="http://www.youtube.com/v/E4Fbk52Mk1w" type="application/x-shockwave-flash" width="400" height="325"></embed></object>',
+                   '[media][/media][youtube]E4Fbk52Mk1w[/youtube]'.bbcode_to_html
+  end
+
   def test_youtube_with_full_url
     full_url = "http://www.youtube.com/watch?feature=player_embedded&v=E4Fbk52Mk1w"
     assert_equal '<object width="400" height="325"><param name="movie" value="http://www.youtube.com/v/E4Fbk52Mk1w"></param><embed src="http://www.youtube.com/v/E4Fbk52Mk1w" type="application/x-shockwave-flash" width="400" height="325"></embed></object>',

--- a/test/ruby_bbcode_vadility_test.rb
+++ b/test/ruby_bbcode_vadility_test.rb
@@ -67,6 +67,20 @@ class RubyBbcodeValidityTest < Minitest::Test
     assert_equal "<span class='bbcode_error' data-bbcode-errors='[\"No text between [media] and [/media] tags.\"]'>[media]</span>[/media][b]E4Fbk52Mk1w[/b]",
                    '[media][/media][b]E4Fbk52Mk1w[/b]'.bbcode_show_errors
   end
+  
+  def test_succeeding_between_texts_for_multi_tags_explicitly_marked_to_require_between_false
+    mydef = {
+      :can_be_empty => {
+        :require_between => false,
+        :multi_tag => true,
+        :description => 'This is a test',
+        :example => '[test]Test here[/test]',
+        :param_tokens => [{:token => :can_be_empty}]
+      }
+    }
+    
+    assert '[can_be_empty][/can_be_empty]'.bbcode_check_validity(mydef) == true
+  end
 
   def test_addition_of_tags
     mydef = {

--- a/test/ruby_bbcode_vadility_test.rb
+++ b/test/ruby_bbcode_vadility_test.rb
@@ -63,6 +63,11 @@ class RubyBbcodeValidityTest < Minitest::Test
     assert_equal ['The URL should start with http:// https://, ftp:// or /, instead of \'illegal url\''], '[url]illegal url[/url]'.bbcode_check_validity
   end
 
+  def test_failing_between_texts_on_multi_tags
+    assert_equal "<span class='bbcode_error' data-bbcode-errors='[\"No text between [media] and [/media] tags.\"]'>[media]</span>[/media][b]E4Fbk52Mk1w[/b]",
+                   '[media][/media][b]E4Fbk52Mk1w[/b]'.bbcode_show_errors
+  end
+
   def test_addition_of_tags
     mydef = {
       :test => {


### PR DESCRIPTION
...en text wasn't given

The test makes it pretty clear.  when "[media][/media]" is parsed, it can be assumed as a default that "require_between" is true.  So it should error the same way "[url][/url]" does.  