### PR TITLE
Unknown tags are treated as text

### DIFF
--- a/lib/ruby-bbcode/tag_info.rb
+++ b/lib/ruby-bbcode/tag_info.rb
@@ -124,6 +124,8 @@ module RubyBBCode
         ti[:text] = tag_info[9]
       end
       ti
+    rescue StandardError => e
+      { complete_match: tag_info[0], is_tag: false, errors: [], text: tag_info[0] }
     end
   end
 end

--- a/test/ruby_bbcode_bbcode_test.rb
+++ b/test/ruby_bbcode_bbcode_test.rb
@@ -182,6 +182,10 @@ class RubyBbcodeBbcodeTest < Minitest::Test
     assert_equal '<span class=\'bbcode_error\' data-bbcode-errors=\'["[li] can only be used in [ul] and [ol]"]\'>[li]</span>[/li]', '[li][/li]'.bbcode_show_errors
   end
 
+  def test_unknown_tags
+    assert_equal '[align=center]This is an unknown tag[/align]', '[align=center]This is an unknown tag[/align]'.bbcode_show_errors
+  end
+
   def test_illegal_unallowed_childs
     assert_equal '[ul]<span class=\'bbcode_error\' data-bbcode-errors=\'["[ul] can only contain [li] and [*] tags, so &quot;Illegal text&quot; is not allowed"]\'>Illegal text</span>[/ul]', '[ul]Illegal text[/ul]'.bbcode_show_errors
     assert_equal '[ul]<span class=\'bbcode_error\' data-bbcode-errors=\'["[ul] can only contain [li] and [*] tags, so [b] is not allowed"]\'>[b]</span>Illegal tag[/b][/ul]', '[ul][b]Illegal tag[/b][/ul]'.bbcode_show_errors


### PR DESCRIPTION
`'[align=center]This is an unknown tag[/align]'.bbcode_to_html` will now properly result in the tag being treated as normal text rather than throwing an error. 

Can later think of a more elaborate and configurable solution, but for now at least it doesn't break
