### PR TITLE
Make behavior of unknown tags configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Upcoming
 --------
 
 * Use rubocup and sonargraph and fix minor issues
+* Make behavior of unknown tags configurable ([#36](https://github.com/veger/ruby-bbcode/issues/36))
 
 Version 2.0.3 - 07-Feb-2018
 ---------------------------

--- a/lib/ruby-bbcode.rb
+++ b/lib/ruby-bbcode.rb
@@ -1,4 +1,5 @@
 require 'tags/tags'
+require 'ruby-bbcode/configuration'
 require 'ruby-bbcode/tag_info'
 require 'ruby-bbcode/tag_sifter'
 require 'ruby-bbcode/tag_node'
@@ -10,6 +11,22 @@ require 'ruby-bbcode/bbtree'
 # The used parser also checks whether the BBCode is valid and gives errors for incorrect BBCode texts.
 module RubyBBCode
   include ::RubyBBCode::Tags
+
+  class << self
+    attr_writer :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.reset
+    @configuration = Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
 
   # This method converts the given text (with BBCode tags) into a HTML representation
   # The escape_html parameter (default: true) escapes HTML tags that were present in the given text and therefore blocking (mallicious) HTML in the original text

--- a/lib/ruby-bbcode/configuration.rb
+++ b/lib/ruby-bbcode/configuration.rb
@@ -1,9 +1,18 @@
 # Configuration holds RubyBBCode configuration
 class Configuration
-  # When true unknown tags are treated as text (default), otherwise an exception is raised
-  attr_accessor :ignore_unknown_tags
+  # Defines how to treat unknown tags
+  # * :exception throws and exception
+  # * :text converts it into a text
+  # * :ignore removes it from the output
+  attr_reader :ignore_unknown_tags
 
   def initialize
-    @ignore_unknown_tags = true
+    @ignore_unknown_tags = :text
+  end
+
+  def ignore_unknown_tags=(value)
+    raise 'ignore_unknown_tags must be either :exception, :text or :ignore' unless %i[exception text ignore].include? value
+
+    @ignore_unknown_tags = value
   end
 end

--- a/lib/ruby-bbcode/configuration.rb
+++ b/lib/ruby-bbcode/configuration.rb
@@ -1,0 +1,9 @@
+# Configuration holds RubyBBCode configuration
+class Configuration
+  # When true unknown tags are treated as text (default), otherwise an exception is raised
+  attr_accessor :ignore_unknown_tags
+
+  def initialize
+    @ignore_unknown_tags = true
+  end
+end

--- a/lib/ruby-bbcode/tag_info.rb
+++ b/lib/ruby-bbcode/tag_info.rb
@@ -105,11 +105,15 @@ module RubyBBCode
         @definition = dictionary[ti[:tag]]
         if !tag_in_dictionary?
           # Tag is not defined in dictionary, so treat as text
-          raise "unknown tag #{ti[:tag]}" unless RubyBBCode.configuration.ignore_unknown_tags
+          raise "unknown tag #{ti[:tag]}" if RubyBBCode.configuration.ignore_unknown_tags == :exception
 
           ti = default_tag_info(tag_info)
           ti[:is_tag] = false
-          ti[:text] = tag_info[0]
+          ti[:text] = if RubyBBCode.configuration.ignore_unknown_tags == :text
+                        tag_info[0]
+                      else
+                        ''
+                      end
         elsif (tag_info[5][0] == '=') && can_have_quick_param?
           quick_param = tag_info[5][1..-1]
           # Get list of parameter values and add them as (regular) parameters

--- a/test/ruby_bbcode_bbcode_test.rb
+++ b/test/ruby_bbcode_bbcode_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class RubyBbcodeBbcodeTest < Minitest::Test
+  def before_setup
+    RubyBBCode.reset
+  end
+
   def test_multiline
     assert_equal "line1\nline2", "line1\nline2".bbcode_show_errors
     assert_equal "line1\r\nline2", "line1\r\nline2".bbcode_show_errors
@@ -180,6 +184,16 @@ class RubyBbcodeBbcodeTest < Minitest::Test
 
   def test_missing_parent_tags
     assert_equal '<span class=\'bbcode_error\' data-bbcode-errors=\'["[li] can only be used in [ul] and [ol]"]\'>[li]</span>[/li]', '[li][/li]'.bbcode_show_errors
+  end
+
+  def test_unknown_tag
+    RubyBBCode.configuration.ignore_unknown_tags = false
+    assert_raises RuntimeError do
+      '[unknown]This is an unknown tag[/unknown]'.bbcode_show_errors
+    end
+
+    RubyBBCode.configuration.ignore_unknown_tags = true
+    assert_equal '[unknown]This is an unknown tag[/unknown]', '[unknown]This is an unknown tag[/unknown]'.bbcode_show_errors
   end
 
   def test_illegal_unallowed_childs

--- a/test/ruby_bbcode_bbcode_test.rb
+++ b/test/ruby_bbcode_bbcode_test.rb
@@ -187,12 +187,15 @@ class RubyBbcodeBbcodeTest < Minitest::Test
   end
 
   def test_unknown_tag
-    RubyBBCode.configuration.ignore_unknown_tags = false
+    RubyBBCode.configuration.ignore_unknown_tags = :exception
     assert_raises RuntimeError do
       '[unknown]This is an unknown tag[/unknown]'.bbcode_show_errors
     end
 
-    RubyBBCode.configuration.ignore_unknown_tags = true
+    RubyBBCode.configuration.ignore_unknown_tags = :ignore
+    assert_equal 'This is an unknown tag', '[unknown]This is an unknown tag[/unknown]'.bbcode_show_errors
+
+    RubyBBCode.configuration.ignore_unknown_tags = :text
     assert_equal '[unknown]This is an unknown tag[/unknown]', '[unknown]This is an unknown tag[/unknown]'.bbcode_show_errors
   end
 

--- a/test/ruby_bbcode_html_test.rb
+++ b/test/ruby_bbcode_html_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class RubyBbcodeHtmlTest < Minitest::Test
+  def before_setup
+    RubyBBCode.reset
+  end
+
   def test_multiline
     assert_equal "line1<br />\nline2", "line1\nline2".bbcode_to_html
     assert_equal "line1<br />\nline2", "line1\r\nline2".bbcode_to_html
@@ -203,6 +207,16 @@ class RubyBbcodeHtmlTest < Minitest::Test
 
     assert_equal '<iframe src="http://player.vimeo.com/video/46141955?badge=0" width="640" height="480" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>',
                  '[vimeo width=640 height=480]46141955[/vimeo]'.bbcode_to_html
+  end
+
+  def test_unknown_tag
+    RubyBBCode.configuration.ignore_unknown_tags = false
+    assert_raises RuntimeError do
+      '[unknown]This is an unknown tag[/unknown]'.bbcode_to_html
+    end
+
+    RubyBBCode.configuration.ignore_unknown_tags = true
+    assert_equal '[unknown]This is an unknown tag[/unknown]', '[unknown]This is an unknown tag[/unknown]'.bbcode_to_html
   end
 
   def test_raised_exceptions

--- a/test/ruby_bbcode_html_test.rb
+++ b/test/ruby_bbcode_html_test.rb
@@ -210,12 +210,15 @@ class RubyBbcodeHtmlTest < Minitest::Test
   end
 
   def test_unknown_tag
-    RubyBBCode.configuration.ignore_unknown_tags = false
+    RubyBBCode.configuration.ignore_unknown_tags = :exception
     assert_raises RuntimeError do
       '[unknown]This is an unknown tag[/unknown]'.bbcode_to_html
     end
 
-    RubyBBCode.configuration.ignore_unknown_tags = true
+    RubyBBCode.configuration.ignore_unknown_tags = :ignore
+    assert_equal 'This is an unknown tag', '[unknown]This is an unknown tag[/unknown]'.bbcode_to_html
+
+    RubyBBCode.configuration.ignore_unknown_tags = :text
     assert_equal '[unknown]This is an unknown tag[/unknown]', '[unknown]This is an unknown tag[/unknown]'.bbcode_to_html
   end
 

--- a/test/ruby_bbcode_validity_test.rb
+++ b/test/ruby_bbcode_validity_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class RubyBbcodeValidityTest < Minitest::Test
+  def before_setup
+    RubyBBCode.reset
+  end
+
   def test_multiple_errors
     input = '[b]Bold not closed, [li]Illegal list item[/li]'
     errors = input.bbcode_check_validity

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class ConfigurationTest < MiniTest::Test
+  def before_setup
+    RubyBBCode.reset
+  end
+
+  def test_configuration
+    assert_equal true, RubyBBCode.configuration.ignore_unknown_tags
+
+    RubyBBCode.configuration.ignore_unknown_tags = false
+
+    assert_equal false, RubyBBCode.configuration.ignore_unknown_tags
+  end
+
+  def test_configuration_reset
+    assert_equal true, RubyBBCode.configuration.ignore_unknown_tags
+
+    RubyBBCode.configuration.ignore_unknown_tags = false
+
+    assert_equal false, RubyBBCode.configuration.ignore_unknown_tags
+
+    RubyBBCode.reset
+
+    assert_equal true, RubyBBCode.configuration.ignore_unknown_tags
+  end
+
+  def test_configuration_block
+    assert_equal true, RubyBBCode.configuration.ignore_unknown_tags
+
+    RubyBBCode.configure do |config|
+      config.ignore_unknown_tags = false
+    end
+
+    assert_equal false, RubyBBCode.configuration.ignore_unknown_tags
+  end
+end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -6,32 +6,32 @@ class ConfigurationTest < MiniTest::Test
   end
 
   def test_configuration
-    assert_equal true, RubyBBCode.configuration.ignore_unknown_tags
+    refute_equal :ignore, RubyBBCode.configuration.ignore_unknown_tags
 
-    RubyBBCode.configuration.ignore_unknown_tags = false
+    RubyBBCode.configuration.ignore_unknown_tags = :ignore
 
-    assert_equal false, RubyBBCode.configuration.ignore_unknown_tags
+    assert_equal :ignore, RubyBBCode.configuration.ignore_unknown_tags
   end
 
   def test_configuration_reset
-    assert_equal true, RubyBBCode.configuration.ignore_unknown_tags
+    refute_equal :exception, RubyBBCode.configuration.ignore_unknown_tags
 
-    RubyBBCode.configuration.ignore_unknown_tags = false
+    RubyBBCode.configuration.ignore_unknown_tags = :exception
 
-    assert_equal false, RubyBBCode.configuration.ignore_unknown_tags
+    assert_equal :exception, RubyBBCode.configuration.ignore_unknown_tags
 
     RubyBBCode.reset
 
-    assert_equal true, RubyBBCode.configuration.ignore_unknown_tags
+    refute_equal :exception, RubyBBCode.configuration.ignore_unknown_tags
   end
 
   def test_configuration_block
-    assert_equal true, RubyBBCode.configuration.ignore_unknown_tags
+    refute_equal :ignore, RubyBBCode.configuration.ignore_unknown_tags
 
     RubyBBCode.configure do |config|
-      config.ignore_unknown_tags = false
+      config.ignore_unknown_tags = :ignore
     end
 
-    assert_equal false, RubyBBCode.configuration.ignore_unknown_tags
+    assert_equal :ignore, RubyBBCode.configuration.ignore_unknown_tags
   end
 end


### PR DESCRIPTION
Unknown tags are treated as text, unless configuration is used to instead raise an exception.

Fixes #33 